### PR TITLE
Complete flags from parent commands

### DIFF
--- a/kongplete.go
+++ b/kongplete.go
@@ -110,8 +110,8 @@ func nodeCommand(node *kong.Node, predictors map[string]complete.Predictor) (*co
 	}
 
 	cmd := complete.Command{
-		Sub:   complete.Commands{},
-		Flags: complete.Flags{},
+		Sub:         complete.Commands{},
+		GlobalFlags: complete.Flags{},
 	}
 
 	for _, child := range node.Children {
@@ -135,9 +135,9 @@ func nodeCommand(node *kong.Node, predictors map[string]complete.Predictor) (*co
 		if err != nil {
 			return nil, err
 		}
-		cmd.Flags["--"+flag.Name] = predictor
+		cmd.GlobalFlags["--"+flag.Name] = predictor
 		if flag.Short != 0 {
-			cmd.Flags["-"+string(flag.Short)] = predictor
+			cmd.GlobalFlags["-"+string(flag.Short)] = predictor
 		}
 	}
 

--- a/kongplete_test.go
+++ b/kongplete_test.go
@@ -69,7 +69,7 @@ func TestComplete(t *testing.T) {
 		},
 		{
 			parser: kong.Must(&cli),
-			want:   []string{"--bar", "--baz", "--lion"},
+			want:   []string{"--bar", "--baz", "--lion", "--help"},
 			line:   "myApp foo -",
 		},
 		{
@@ -84,7 +84,7 @@ func TestComplete(t *testing.T) {
 		},
 		{
 			parser: kong.Must(&cli),
-			want:   []string{"--bar", "--baz", "--lion"},
+			want:   []string{"--bar", "--baz", "--lion", "--help"},
 			line:   "myApp foo --baz -",
 		},
 		{
@@ -105,7 +105,7 @@ func TestComplete(t *testing.T) {
 		},
 		{
 			parser: kong.Must(&cli),
-			want:   []string{"-n", "--number", "--omg"},
+			want:   []string{"-n", "--number", "--omg", "--help"},
 			line:   "myApp bar -",
 		},
 	}


### PR DESCRIPTION
fixes #3 

This turns out to be a simple change.  We only needed to populate the command's GlobalFlags instead of Flags.
