### PR TITLE
Don't emit hidden commands or flags in output

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,7 @@ var shellCli struct {
 		User      string `help:"Run as user." short:"u" default:"default"`
 		Force     bool   `help:"Force removal." short:"f"`
 		Recursive bool   `help:"Recursively remove files." short:"r"`
+		Hidden    string `help:"A hidden flag" hidden`
 
 		Paths []string `arg:"" help:"Paths to remove." type:"path" name:"path" predictor:"file"`
 	} `cmd:"" help:"Remove files."`
@@ -33,6 +34,8 @@ var shellCli struct {
 	Ls struct {
 		Paths []string `arg:"" optional:"" help:"Paths to list." type:"path" predictor:"file"`
 	} `cmd:"" help:"List paths."`
+
+	Hidden struct {} `cmd:"" help:"A hidden command" hidden`
 
 	Debug bool `help:"Debug mode."`
 
@@ -61,6 +64,8 @@ func main() {
 		fmt.Println(shellCli.Rm.Paths, shellCli.Rm.Force, shellCli.Rm.Recursive)
 
 	case "ls":
+
+	case "hidden":
 	}
 }
 

--- a/kongplete.go
+++ b/kongplete.go
@@ -116,7 +116,7 @@ func nodeCommand(node *kong.Node, predictors map[string]complete.Predictor) (*co
 	}
 
 	for _, child := range node.Children {
-		if child == nil {
+		if child == nil || child.Hidden {
 			continue
 		}
 		childCmd, err := nodeCommand(child, predictors)

--- a/kongplete.go
+++ b/kongplete.go
@@ -129,7 +129,7 @@ func nodeCommand(node *kong.Node, predictors map[string]complete.Predictor) (*co
 	}
 
 	for _, flag := range node.Flags {
-		if flag == nil {
+		if flag == nil || flag.Hidden {
 			continue
 		}
 		predictor, err := flagPredictor(flag, predictors)

--- a/kongplete_test.go
+++ b/kongplete_test.go
@@ -45,6 +45,7 @@ func TestComplete(t *testing.T) {
 			Number  int    `kong:"short=n,enum='1,2,3'"`
 			BooFlag bool   `kong:"name=boofl,short=b"`
 		} `kong:"cmd"`
+		Baz struct{} `kong:"cmd,hidden"`
 	}
 
 	tests := []completeTest{

--- a/kongplete_test.go
+++ b/kongplete_test.go
@@ -33,6 +33,7 @@ func TestComplete(t *testing.T) {
 			Embedded embed  `kong:"embed"`
 			Bar      string `kong:"predictor=things"`
 			Baz      bool
+			Qux      bool `kong:"hidden"`
 			Rabbit   struct {
 			} `kong:"cmd"`
 			Duck struct {


### PR DESCRIPTION
## What

This PR makes kongplete respect the `hidden` tag on both commands and flags. 

## Why

If you don't want a command or flag appearing in the normal help output, you probably don't want it showing up in shell completions either.