### PR TITLE
Use Markdown links in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 You kongplete me.
 
 kongplete lets you generate shell completions for your command-line programs using
-github.com/alecthomas/kong and github.com/posener/complete.
+[github.com/alecthomas/kong](https://github.com/alecthomas/kong) and [github.com/posener/complete](https://github.com/posener/complete).
 
 ## Examples
 


### PR DESCRIPTION
With markdown links, the references to kong and complete are clickable, which is slightly more convenient.