### PR TITLE
Add support for command aliases

### DIFF
--- a/kongplete.go
+++ b/kongplete.go
@@ -124,6 +124,9 @@ func nodeCommand(node *kong.Node, predictors map[string]complete.Predictor) (*co
 		}
 		if childCmd != nil {
 			cmd.Sub[child.Name] = *childCmd
+			for _, a := range child.Aliases {
+				cmd.Sub[a] = *childCmd
+			}
 		}
 	}
 

--- a/kongplete_test.go
+++ b/kongplete_test.go
@@ -43,14 +43,14 @@ func TestComplete(t *testing.T) {
 			OMG     string `kong:"required,enum='oh,my,gizzles'"`
 			Number  int    `kong:"required,short=n,enum='1,2,3'"`
 			BooFlag bool   `kong:"name=boofl,short=b"`
-		} `kong:"cmd"`
+		} `kong:"cmd,aliases='b'"`
 		Baz struct{} `kong:"cmd,hidden"`
 	}
 
 	for _, td := range []completeTest{
 		{
 			parser: kong.Must(&cli),
-			want:   []string{"foo", "bar"},
+			want:   []string{"foo", "bar", "b"},
 			line:   "myApp ",
 		},
 		{
@@ -101,13 +101,33 @@ func TestComplete(t *testing.T) {
 		},
 		{
 			parser: kong.Must(&cli),
+			want:   []string{"bar", "b"},
+			line:   "myApp b",
+		},
+		{
+			parser: kong.Must(&cli),
+			want:   []string{"thing1", "thing2"},
+			line:   "myApp b ",
+		},
+		{
+			parser: kong.Must(&cli),
 			want:   []string{"thing1", "thing2"},
 			line:   "myApp bar thing",
 		},
 		{
 			parser: kong.Must(&cli),
+			want:   []string{"thing1", "thing2"},
+			line:   "myApp b thing",
+		},
+		{
+			parser: kong.Must(&cli),
 			want:   []string{"otherthing1", "otherthing2"},
 			line:   "myApp bar thing1 ",
+		},
+		{
+			parser: kong.Must(&cli),
+			want:   []string{"otherthing1", "otherthing2"},
+			line:   "myApp b thing1 ",
 		},
 		{
 			parser: kong.Must(&cli),


### PR DESCRIPTION
This change allows kongplete to recognize command aliases. 

If you have something like "my-cli update ... " and "up" is an alias for update, kongplete wouldn't recognize up as valid. This not only affected completion for the "up" command, but also for commands and flags that followed. 

The fix is simple and small. This PR includes tests, and I also tested the behavior in a CLI I'm contributing to, to ensure that the user behavior is as expectedd. 