### PR TITLE
Change module in go.mod to match the actual url

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/willabides/kongplete
+module github.com/WillAbides/kongplete
 
 go 1.17
 


### PR DESCRIPTION
On case sensitive filesystems the module url and the actual github url must match case, otherwise go complains with:

go: github.com/WillAbides/kongplete@v0.3.0: parsing go.mod:
        module declares its path as: github.com/willabides/kongplete
                but was required as: github.com/WillAbides/kongplete