### PR TITLE
Add support for cumulative predictors

### DIFF
--- a/internal/positionalpredictor/positional.go
+++ b/internal/positionalpredictor/positional.go
@@ -11,6 +11,7 @@ type PositionalPredictor struct {
 	Predictors []complete.Predictor
 	ArgFlags   []string
 	BoolFlags  []string
+	IsCumulative bool
 }
 
 // Predict implements complete.Predict
@@ -25,6 +26,9 @@ func (p *PositionalPredictor) Predict(a complete.Args) []string {
 func (p *PositionalPredictor) predictor(a complete.Args) complete.Predictor {
 	position := p.predictorIndex(a)
 	complete.Log("predicting positional argument(%d)", position)
+	if p.IsCumulative && position > len(p.Predictors)-1 {
+		return p.Predictors[len(p.Predictors)-1]
+	}
 	if position < 0 || position > len(p.Predictors)-1 {
 		return nil
 	}

--- a/internal/positionalpredictor/positional.go
+++ b/internal/positionalpredictor/positional.go
@@ -8,9 +8,9 @@ import (
 
 // PositionalPredictor is a predictor for positional arguments
 type PositionalPredictor struct {
-	Predictors []complete.Predictor
-	ArgFlags   []string
-	BoolFlags  []string
+	Predictors   []complete.Predictor
+	ArgFlags     []string
+	BoolFlags    []string
 	IsCumulative bool
 }
 
@@ -26,7 +26,7 @@ func (p *PositionalPredictor) Predict(a complete.Args) []string {
 func (p *PositionalPredictor) predictor(a complete.Args) complete.Predictor {
 	position := p.predictorIndex(a)
 	complete.Log("predicting positional argument(%d)", position)
-	if p.IsCumulative && position > len(p.Predictors)-1 {
+	if p.IsCumulative && position >= len(p.Predictors) {
 		return p.Predictors[len(p.Predictors)-1]
 	}
 	if position < 0 || position > len(p.Predictors)-1 {

--- a/internal/positionalpredictor/positional_test.go
+++ b/internal/positionalpredictor/positional_test.go
@@ -55,6 +55,29 @@ func TestPositionalPredictor_predictor(t *testing.T) {
 	}
 }
 
+func TestPositionalPredictor_cumulativepredictor(t *testing.T) {
+	predictor1 := complete.PredictSet("1")
+	predictor2 := complete.PredictSet("2")
+	posPredictor := &PositionalPredictor{
+		Predictors:   []complete.Predictor{predictor1, predictor2},
+		IsCumulative: true,
+	}
+
+	for args, want := range map[string]complete.Predictor{
+		``:             predictor1,
+		`foo`:          predictor1,
+		`foo `:         predictor2,
+		`foo bar`:      predictor2,
+		`foo bar `:     predictor2,
+		`foo bar baz `: predictor2,
+	} {
+		t.Run(args, func(t *testing.T) {
+			got := posPredictor.predictor(newArgs("app " + args))
+			assert.Equal(t, want, got)
+		})
+	}
+}
+
 // The code below is taken from https://github.com/posener/complete/blob/f6dd29e97e24f8cb51a8d4050781ce2b238776a4/args.go
 // to assist in tests.
 

--- a/kongplete.go
+++ b/kongplete.go
@@ -141,6 +141,11 @@ func nodeCommand(node *kong.Node, predictors map[string]complete.Predictor) (*co
 	}
 
 	boolFlags, nonBoolFlags := boolAndNonBoolFlags(node.Flags)
+	isCumulative := false
+	if len(node.Positional) > 0 && node.Positional[len(node.Positional)-1].IsCumulative() {
+		isCumulative = true
+	}
+
 	pps, err := positionalPredictors(node.Positional, predictors)
 	if err != nil {
 		return nil, err
@@ -149,6 +154,7 @@ func nodeCommand(node *kong.Node, predictors map[string]complete.Predictor) (*co
 		Predictors: pps,
 		ArgFlags:   flagNamesWithHyphens(nonBoolFlags...),
 		BoolFlags:  flagNamesWithHyphens(boolFlags...),
+		IsCumulative: isCumulative,
 	}
 
 	return &cmd, nil

--- a/kongplete.go
+++ b/kongplete.go
@@ -151,9 +151,9 @@ func nodeCommand(node *kong.Node, predictors map[string]complete.Predictor) (*co
 		return nil, err
 	}
 	cmd.Args = &positionalpredictor.PositionalPredictor{
-		Predictors: pps,
-		ArgFlags:   flagNamesWithHyphens(nonBoolFlags...),
-		BoolFlags:  flagNamesWithHyphens(boolFlags...),
+		Predictors:   pps,
+		ArgFlags:     flagNamesWithHyphens(nonBoolFlags...),
+		BoolFlags:    flagNamesWithHyphens(boolFlags...),
 		IsCumulative: isCumulative,
 	}
 

--- a/kongplete_test.go
+++ b/kongplete_test.go
@@ -46,7 +46,7 @@ func TestComplete(t *testing.T) {
 		} `kong:"cmd"`
 		Baz struct{} `kong:"cmd,hidden"`
 		Pos struct {
-			Cumulative   []string `kong:"arg,predictor=things"`
+			Cumulative []string `kong:"arg,predictor=things"`
 		} `kong:"cmd"`
 	}
 

--- a/kongplete_test.go
+++ b/kongplete_test.go
@@ -46,7 +46,6 @@ func TestComplete(t *testing.T) {
 		} `kong:"cmd"`
 		Baz struct{} `kong:"cmd,hidden"`
 		Pos struct {
-			RepeatedFlag []string `kong:"name=r,predictor=otherthings"`
 			Cumulative   []string `kong:"arg,predictor=things"`
 		} `kong:"cmd"`
 	}
@@ -56,11 +55,6 @@ func TestComplete(t *testing.T) {
 			parser: kong.Must(&cli),
 			want:   []string{"thing1", "thing2"},
 			line:   "myApp pos thing1 ",
-		},
-		{
-			parser: kong.Must(&cli),
-			want:   []string{"otherthing1", "otherthing2"},
-			line:   "myApp pos thing1 --r otherthings1 --r ",
 		},
 		{
 			parser: kong.Must(&cli),

--- a/kongplete_test.go
+++ b/kongplete_test.go
@@ -46,7 +46,7 @@ func TestComplete(t *testing.T) {
 		} `kong:"cmd"`
 		Baz struct{} `kong:"cmd,hidden"`
 		Pos struct {
-			RepeatedFlag []string `kong:"name=r,predictor=things"`
+			RepeatedFlag []string `kong:"name=r,predictor=otherthings"`
 			Cumulative   []string `kong:"arg,predictor=things"`
 		} `kong:"cmd"`
 	}
@@ -59,8 +59,8 @@ func TestComplete(t *testing.T) {
 		},
 		{
 			parser: kong.Must(&cli),
-			want:   []string{"thing1", "thing2"},
-			line:   "myApp pos thing1 --r thing1 --r ",
+			want:   []string{"otherthing1", "otherthing2"},
+			line:   "myApp pos thing1 --r otherthings1 --r ",
 		},
 		{
 			parser: kong.Must(&cli),

--- a/kongplete_test.go
+++ b/kongplete_test.go
@@ -45,12 +45,26 @@ func TestComplete(t *testing.T) {
 			BooFlag bool   `kong:"name=boofl,short=b"`
 		} `kong:"cmd"`
 		Baz struct{} `kong:"cmd,hidden"`
+		Pos struct {
+			RepeatedFlag []string `kong:"name=r,predictor=things"`
+			Cumulative   []string `kong:"arg,predictor=things"`
+		} `kong:"cmd"`
 	}
 
 	for _, td := range []completeTest{
 		{
 			parser: kong.Must(&cli),
-			want:   []string{"foo", "bar"},
+			want:   []string{"thing1", "thing2"},
+			line:   "myApp pos thing1 ",
+		},
+		{
+			parser: kong.Must(&cli),
+			want:   []string{"thing1", "thing2"},
+			line:   "myApp pos thing1 --r thing1 --r ",
+		},
+		{
+			parser: kong.Must(&cli),
+			want:   []string{"foo", "bar", "pos"},
 			line:   "myApp ",
 		},
 		{


### PR DESCRIPTION
Adds support for positional arguments -- slices, maps.

Kong can append all remaining arguments into a slice or map if defined. We can detect the presence of a cumulative positional argument if there exists positional arguments and the last one is cumulative (either map or set).

If positional arguments is either a map or set, we may continue to use the last positional predictor that is defined.