### PR TITLE
Add a command argument for choosing shell

### DIFF
--- a/completion_install.go
+++ b/completion_install.go
@@ -12,12 +12,13 @@ import (
 
 // InstallCompletions is a kong command for installing or uninstalling shell completions
 type InstallCompletions struct {
+	Shell     string `arg:"" name:"shell" optional:"" help:"The shell to install completion for. If not provided, the user's login shell will be used."`
 	Uninstall bool
 }
 
 // BeforeApply installs completion into the users shell.
-func (c *InstallCompletions) BeforeApply(ctx *kong.Context) error {
-	err := installCompletionFromContext(ctx)
+func (c *InstallCompletions) AfterApply(ctx *kong.Context) error {
+	err := c.installCompletionFromContext(ctx)
 	if err != nil {
 		return err
 	}
@@ -41,11 +42,20 @@ complete -f -c ${cmd} -a "(__complete_${cmd})"
 }
 
 // installCompletionFromContext writes shell completion for the given command.
-func installCompletionFromContext(ctx *kong.Context) error {
-	shell, err := loginshell.Shell()
-	if err != nil {
-		return fmt.Errorf("couldn't determine user's shell: %w", err)
+func (c *InstallCompletions) installCompletionFromContext(ctx *kong.Context) error {
+	var shell string
+	var err error
+
+	// If the user provided a shell, use that. Otherwise, use the user's login shell.
+	if c.Shell != "" {
+		shell = c.Shell
+	} else {
+		shell, err = loginshell.Shell()
+		if err != nil {
+			return fmt.Errorf("couldn't determine user's shell: %w", err)
+		}
 	}
+
 	bin, err := os.Executable()
 	if err != nil {
 		return fmt.Errorf("couldn't find absolute path to ourselves: %w", err)


### PR DESCRIPTION
This PR adds a positional argument to the `InstallCompletions` command for choosing the shell.
This allows e.g. to put `source <$(./cli completions bash)` in `~/.bashrc` and `source <$(./cli completions zsh)` into `~/.zshrc`

Tested locally with the Crossplane CLI:
```
# zsh is my login shell
$ crossplane completions
autoload -U +X bashcompinit && bashcompinit
complete -C /Users/thund/Repos/privat/crossplane/crossplane crossplane

$ crossplane bash
complete -C /Users/thund/Repos/privat/crossplane/crossplane crossplane

$ crossplane zsh
autoload -U +X bashcompinit && bashcompinit
complete -C /Users/thund/Repos/privat/crossplane/crossplane crossplane

$ crossplane fish
function __complete_crossplane
    set -lx COMP_LINE (commandline -cp)
    test -z (commandline -ct)
    and set COMP_LINE "$COMP_LINE "
    /Users/thund/Repos/privat/crossplane/crossplane
end
complete -f -c crossplane -a "(__complete_crossplane)"

$ crossplane pwsh
Usage: crossplane completions [<shell>] [flags]

Get shell (bash/zsh/fish) completions. You can source this command to get
completions for the login shell. Example: 'source <(crossplane completions)'

Arguments:
  [<shell>]    The shell to install completion for. If not provided, the user's
               login shell will be used.

Flags:
  -h, --help         Show context-sensitive help.
      --verbose      Print verbose logging statements.

      --uninstall

crossplane: error: unsupported shell pwsh
```